### PR TITLE
feat: consistent return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,23 @@ Creates middleware that will accumulate state.
 
 ```typescript
 import express from 'express'
-import { ioMiddleware, FINISHED } from 'io-middleware'
+import { ioMiddleware, CONTINUE, FINISHED } from 'io-middleware'
 
 express().get(
   '/user/:id',
   ioMiddleware(
     null, // initial value
-    async (req, res) => fetchUser(req.params.id),
-    async (req, res, user) => ({ name: user.name, email: user.email }),
+    async (req, res) => ({
+      type: CONTINUE,
+      state: await fetchUser(req.params.id),
+    }),
+    (req, res, user) => ({
+      type: CONTINUE,
+      state: { name: user.name, email: user.email },
+    }),
     (req, res, state) => {
       res.json(state)
-      return FINISHED // prevents any further middleware being called
+      return { type: FINISHED } // prevents any further middleware being called
     },
   ),
 )
@@ -63,13 +69,13 @@ If we were to create another route and forget to assign an `articleId` to our lo
 Strongly typing our middleware can help us ensure that the required state has been populated.
 
 ```typescript
-import { FINISH, ioMiddleware, IOMiddleware } from 'io-middleware'
+import { CONTINUE, FINISH, ioMiddleware, IOMiddleware } from 'io-middleware'
 
 function articleInfo<I>(): IOMiddleware<I, I & { articleId: string }> {
   return (req, res, state) => {
     const articleId = getArticleFromReferrer(req)
     if (!articleId) throw new ServerError(404)
-    return { ...state, articleId }
+    return { type: CONTINUE, state: { ...state, articleId } }
   }
 }
 
@@ -80,7 +86,7 @@ function partitionKey<I extends { articleId: string }>(): IOMiddleware<
   return (req, res, state) => {
     const partitionKey = partitionLookUp(state.articleId)
     if (!partitionKey) throw new ServerError(404)
-    return { ...state, partitionKey }
+    return { type: CONTINUE, state: { ...state, partitionKey } }
   }
 }
 
@@ -92,7 +98,7 @@ express().get(
     partitionKey(),
     (req, res, state) => {
       res.json(state)
-      return FINISH
+      return { type: FINISH }
     },
   ),
 )

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,10 @@
 import { Request, Response } from 'express'
-import type { CONTINUE, FINISH, BREAK } from './index.js'
+
+export const BREAK = Symbol.for('io-middleware/break')
+
+export const NEXT = Symbol.for('io-middleware/continue')
+
+export const FINISH = Symbol.for('io-middleware/finish')
 
 export interface IOMiddleware<
   I,
@@ -17,20 +22,20 @@ export interface IOMiddleware<
   ): Asyncable<IOMiddlewareOutput<O>>
 }
 
-interface Continue<T> {
-  type: typeof CONTINUE
+export interface Next<T> {
+  type: typeof NEXT
   state: T
 }
 
-interface Break {
+export interface Break {
   type: typeof BREAK
 }
 
-interface Finish {
+export interface Finish {
   type: typeof FINISH
 }
 
-export type IOMiddlewareOutput<T> = Continue<T> | Break | Finish
+export type IOMiddlewareOutput<T> = Next<T> | Break | Finish
 
 export interface ParamsDictionary {
   [key: string]: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express'
-import type { FINISH, BREAK } from './index.js'
+import type { CONTINUE, FINISH, BREAK } from './index.js'
 
 export interface IOMiddleware<
   I,
@@ -14,8 +14,23 @@ export interface IOMiddleware<
     req: Request<P, ResBody, ReqBody, ReqQuery, LocalsObj>,
     res: Response<ResBody, LocalsObj>,
     input: I,
-  ): Asyncable<O | typeof BREAK | typeof FINISH>
+  ): Asyncable<IOMiddlewareOutput<O>>
 }
+
+interface Continue<T> {
+  type: typeof CONTINUE
+  state: T
+}
+
+interface Break {
+  type: typeof BREAK
+}
+
+interface Finish {
+  type: typeof FINISH
+}
+
+export type IOMiddlewareOutput<T> = Continue<T> | Break | Finish
 
 export interface ParamsDictionary {
   [key: string]: string

--- a/test/io-middleware.ts
+++ b/test/io-middleware.ts
@@ -3,25 +3,32 @@ import request from 'supertest'
 import assert from 'node:assert'
 import { test } from 'node:test'
 import { setTimeout } from 'node:timers/promises'
-import { FINISH, BREAK, IOMiddleware, ioMiddleware } from '../src/index.js'
+import {
+  FINISH,
+  BREAK,
+  IOMiddleware,
+  ioMiddleware,
+  CONTINUE,
+} from '../src/index.js'
 
 test('passes state from one middleware to the next', (_, done) => {
   const app = express().use(
     ioMiddleware(
       {},
-      (req, res, state): { foo: string } => {
+      (req, res, state) => {
         assert.ok(!!req.headers)
         assert.ok(!!res.send)
         assert.deepStrictEqual(state, {})
-        return { foo: 'bar' }
+        return { type: CONTINUE, state: { foo: 'bar' } }
       },
       (_req, _res, state) => {
         assert.deepStrictEqual(state, { foo: 'bar' })
-        return 'success'
+        return { type: CONTINUE, state: 'success' }
       },
       async (_req, _res, state) => {
         await setTimeout(5)
         assert.strictEqual(state, 'success')
+        return { type: BREAK }
       },
     ),
     (_, res) => res.sendStatus(200),
@@ -34,13 +41,13 @@ test('stopping middleware from continuing', (_, done) => {
   const app = express().use(
     ioMiddleware(
       {},
-      (req, res, state): { foo: string } => {
+      (req, res, state) => {
         assert.ok(!!req.headers)
         assert.ok(!!res.send)
         assert.deepStrictEqual(state, {})
-        return { foo: 'bar' }
+        return { type: CONTINUE, state: { foo: 'bar' } }
       },
-      () => BREAK,
+      () => ({ type: BREAK }),
       () => {
         throw new Error('Middleware did not halt')
       },
@@ -57,7 +64,7 @@ test('preventing any further middleware being called', (_, done) => {
       {},
       (_, res) => {
         res.sendStatus(200)
-        return FINISH
+        return { type: FINISH }
       },
       () => {
         throw new Error('Middleware did not finish')
@@ -73,7 +80,10 @@ test('preventing any further middleware being called', (_, done) => {
 
 test('types with separate functions', () => {
   function foo(): IOMiddleware<{}, { foo: string }> {
-    return (_req, _res, state) => ({ ...state, foo: 'bar' })
+    return (_req, _res, state) => ({
+      type: CONTINUE,
+      state: { ...state, foo: 'bar' },
+    })
   }
 
   function success(): IOMiddleware<
@@ -81,7 +91,9 @@ test('types with separate functions', () => {
     { foo: string; mung: number }
   > {
     return (_req, _res, state) =>
-      state.foo === 'rab' ? BREAK : { ...state, mung: 1 }
+      state.foo === 'rab'
+        ? { type: BREAK }
+        : { type: CONTINUE, state: { ...state, mung: 1 } }
   }
 
   express().use(ioMiddleware({}, foo(), success()))


### PR DESCRIPTION
Ensuring that there's a return type for all middleware and that undefined returns aren't unsurprisingly inferred.

BREAKING CHANGE: All ioMiddleware functions now need to return the correct schema ({ type: Symbol })